### PR TITLE
Implement repeat client-side

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,6 @@ import * as pipe from "./pipe"
 import { UserError } from "./user_error"
 import * as workspace from "./workspace"
 
-
 /** the action that should happen when the user saves a file */
 enum ActionOnSave {
   none,
@@ -50,7 +49,7 @@ async function testFileLine() {
 }
 
 async function repeatTest() {
-  if (lastTest == null) {
+  if (!lastTest) {
     notification.display("no test to repeat")
     return
   }
@@ -65,7 +64,7 @@ async function stopTest() {
 
 /// provides a function that executes the given function and logs UserErrors
 function wrapLogger(f: () => Promise<void>): () => Promise<void> {
-  const runAndCatch = async function (f: () => Promise<void>) {
+  const runAndCatch = async function(f: () => Promise<void>) {
     try {
       await f()
     } catch (e) {
@@ -82,7 +81,6 @@ function wrapLogger(f: () => Promise<void>): () => Promise<void> {
   }
   return runAndCatch.bind(null, f)
 }
-
 
 function switchAutoRepeat() {
   if (actionOnSave === ActionOnSave.repeatLastTest) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,6 +4,17 @@ import * as pipe from "./pipe"
 import { UserError } from "./user_error"
 import * as workspace from "./workspace"
 
+
+/** the action that should happen when the user saves a file */
+enum ActionOnSave {
+  none,
+  testCurrentFile,
+  repeatLastTest
+}
+
+let actionOnSave: ActionOnSave = ActionOnSave.none
+let lastTest: string | undefined = undefined
+
 export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand("contest-vscode.testAll", wrapLogger(testAll)),
@@ -19,25 +30,32 @@ export function activate(context: vscode.ExtensionContext) {
 
 async function testAll() {
   notification.display("testing all files")
-  await pipe.send(`{ "command": "testAll" }`)
+  lastTest = `{ "command": "testAll" }`
+  await pipe.send(lastTest)
 }
 
 async function testFile() {
   const relPath = workspace.currentFile()
   notification.display(`testing file ${relPath}`)
-  await pipe.send(`{ "command": "testFile", "file": "${relPath}" }`)
+  lastTest = `{ "command": "testFile", "file": "${relPath}" }`
+  await pipe.send(lastTest)
 }
 
 async function testFileLine() {
   const relPath = workspace.currentFile()
   const line = workspace.currentLine() + 1
   notification.display(`testing function at ${relPath}:${line}`)
-  await pipe.send(`{ "command": "testFileLine", "file": "${relPath}", "line": ${line} }`)
+  lastTest = `{ "command": "testFileLine", "file": "${relPath}", "line": ${line} }`
+  await pipe.send(lastTest)
 }
 
 async function repeatTest() {
+  if (lastTest == null) {
+    notification.display("no test to repeat")
+    return
+  }
   notification.display("repeating the last test")
-  await pipe.send(`{ "command": "repeatTest" }`)
+  await pipe.send(lastTest)
 }
 
 async function stopTest() {
@@ -47,7 +65,7 @@ async function stopTest() {
 
 /// provides a function that executes the given function and logs UserErrors
 function wrapLogger(f: () => Promise<void>): () => Promise<void> {
-  const runAndCatch = async function(f: () => Promise<void>) {
+  const runAndCatch = async function (f: () => Promise<void>) {
     try {
       await f()
     } catch (e) {
@@ -65,14 +83,6 @@ function wrapLogger(f: () => Promise<void>): () => Promise<void> {
   return runAndCatch.bind(null, f)
 }
 
-/** the action that should happen when the user saves a file */
-enum ActionOnSave {
-  none,
-  testCurrentFile,
-  repeatLastTest
-}
-
-let actionOnSave: ActionOnSave = ActionOnSave.none
 
 function switchAutoRepeat() {
   if (actionOnSave === ActionOnSave.repeatLastTest) {

--- a/text-runner/commands.ts
+++ b/text-runner/commands.ts
@@ -11,8 +11,8 @@ export function commands(action: tr.actions.Args) {
 }
 
 function exportedCommands() {
-  const __dirname = url.fileURLToPath(new URL(".", import.meta.url))
-  const configPath = path.join(__dirname, "..", "package.json")
+  const dirname = url.fileURLToPath(new URL(".", import.meta.url))
+  const configPath = path.join(dirname, "..", "package.json")
   const config = JSON.parse(fs.readFileSync(configPath, "utf-8"))
   const result: string[] = []
   const commandRE = /^contest-vscode\./


### PR DESCRIPTION
Relying on the server to repeat is not a good user experience because in real life one ends up stopping and restarting the server quite a bit. With this new implementation the stored last command survives a reboot of the server component.